### PR TITLE
Fix Windows release workflow dependency setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
   build:
     name: Build on Windows
     runs-on: windows-latest
+    defaults:
+      run:
+        shell: pwsh
 
     steps:
       # 1. Check out the repository's code, including submodules.
@@ -25,12 +28,15 @@ jobs:
 
       # 2. Set up build dependencies for Windows using Chocolatey.
       - name: Install dependencies
-        run: choco install cmake gperf tidy
+        run: choco install -y --no-progress cmake gperf tidy.portable
           
       # 3. Get the version number from the Git tag (e.g., v1.2.3 -> 1.2.3).
       - name: Get the version
         id: get_version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $env:GITHUB_ENV
+        run: |
+          $tag = '${{ github.ref }}'
+          $version = $tag -replace '^refs/tags/', ''
+          "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       # 4. Configure the project using CMake.
       - name: Configure CMake
@@ -49,10 +55,12 @@ jobs:
       # 7. Package the Windows executables into a .zip archive.
       - name: Package artifacts
         run: |
-          mkdir release
-          copy build\Release\hoedown.exe release\
-          copy build\Release\smartypants.exe release\
-          7z a hoedown-${{ env.VERSION }}-windows-latest.zip .\release\*
+          New-Item -ItemType Directory -Path release -Force | Out-Null
+          Copy-Item build\Release\hoedown.exe release\
+          Copy-Item build\Release\smartypants.exe release\
+          $zipName = "hoedown-$env:VERSION-windows-x64.zip"
+          if (Test-Path $zipName) { Remove-Item $zipName }
+          Compress-Archive -Path release\* -DestinationPath $zipName
 
       # 8. Upload the created .zip file as a workflow artifact.
       - name: Upload artifact
@@ -67,6 +75,8 @@ jobs:
     name: Create GitHub Release
     runs-on: ubuntu-latest
     needs: build # Waits for the Windows build to complete.
+    permissions:
+      contents: write
 
     steps:
       # 1. Download the .zip archive from the build job.
@@ -77,7 +87,7 @@ jobs:
 
       # 2. Create the GitHub Release and upload the .zip file to it.
       - name: Create Release and Upload Assets
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           draft: true
           generate_release_notes: true


### PR DESCRIPTION
## Summary
- ensure the Windows build job runs PowerShell commands and installs tidy via Chocolatey
- fix version extraction and package the release with Compress-Archive
- grant release permissions and update the GitHub Release action to v2

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68df3c27dce883228dd9b5859173b7c5